### PR TITLE
python models: add basic SQLite models

### DIFF
--- a/models/boss_relics.py
+++ b/models/boss_relics.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS bossRelics (
+        runId TEXT,
+        choiceNum INTEGER,
+        option TEXT,
+        picked INTEGER,
+        PRIMARY KEY (runId, choiceNum, option)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    choiceNum = 0
+    for choice in fjson["boss_relics"]:
+        choiceNum = choiceNum + 1
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO bossRelics (
+            runId,
+            choiceNum,
+            option,
+            picked
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {choiceNum},
+            "{choice["picked"]}",
+            1
+        );
+        """)
+
+        for notPicked in choice["not_picked"]:
+            connection.execute(f"""
+            INSERT OR IGNORE INTO bossRelics (
+                runId,
+                choiceNum,
+                option,
+                picked
+            ) VALUES (
+                "{fjson["play_id"]}",
+                {choiceNum},
+                "{notPicked}",
+                0
+            );
+            """)

--- a/models/campfire_choices.py
+++ b/models/campfire_choices.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS campfireChoices (
+        runId TEXT,
+        floor INTEGER,
+        key TEXT,
+        data TEXT,
+        PRIMARY KEY (runId, floor, key)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    for choice in fjson["campfire_choices"]:
+        connection.execute(f"""
+        INSERT OR IGNORE INTO campfireChoices (
+            runId,
+            floor,
+            key,
+            data
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {choice["floor"]},
+            "{choice["key"]}",
+            {"NULL" if "data" not in choice else f'"{choice["data"]}"'}
+        );
+        """)

--- a/models/card_choices.py
+++ b/models/card_choices.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import cards
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS cardChoices (
+        runId TEXT,
+        choiceNum INTEGER,
+        floor INTEGER,
+        option TEXT,
+        picked INTEGER,
+        PRIMARY KEY (runId, choiceNum)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    choiceNum = 0
+    for choice in fjson["card_choices"]:
+        choiceNum = choiceNum + 1
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO cardChoices (
+            runId,
+            choiceNum,
+            floor,
+            option,
+            picked
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {choiceNum},
+            {choice["floor"]},
+            "{cards.to_modern(choice["picked"])}",
+            1
+        );
+        """)
+
+        for notPicked in choice["not_picked"]:
+            connection.execute(f"""
+            INSERT OR IGNORE INTO cardChoices (
+                runId,
+                choiceNum,
+                floor,
+                option,
+                picked
+            ) VALUES (
+                "{fjson["play_id"]}",
+                {choiceNum},
+                {choice["floor"]},
+                "{cards.to_modern(notPicked)}",
+                0
+            );
+            """)

--- a/models/cards.py
+++ b/models/cards.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+idToName = {
+    "Adaption": "Rush Down",
+    "Auto Shields": "Auto-Shields",
+    "BootSequence": "Boot Sequence",
+    "ClearTheMind": "Tranquility",
+    "Conserve Battery": "Charge Battery",
+    "Crippling Poison": "Crippling Cloud",
+    "Defend_B": "Defend",
+    "Defend_G": "Defend",
+    "Defend_P": "Defend",
+    "Defend_R": "Defend",
+    "Fasting2": "Fasting",
+    "Gash": "Claw",
+    "Ghostly": "Apparition",
+    "Lockon": "Bullseye",
+    "Night Terror": "Nightmare",
+    "PathToVictory": "Pressure Points",
+    "Redo": "Recursion",
+    "Steam Power": "Overclock",
+    "Steam": "Steam Barrier",
+    "Strike_B": "Strike",
+    "Strike_G": "Strike",
+    "Strike_P": "Strike",
+    "Strike_R": "Strike",
+    "Underhanded Strike": "Sneaky Strike",
+    "Venomology": "Alechemize",
+    "Wireheading": "Foresight",
+    "Wraith Form v2": "Wraith Form",
+}
+
+def to_modern(card):
+    cardParts = card.split("+")
+
+    cardName = cardParts[0]
+    if cardName in idToName:
+        cardName = idToName[cardName]
+    
+    if len(cardParts) == 2:
+        cardName = cardName + "+" + cardParts[1]
+
+    return cardName

--- a/models/current_gold_per_floor.py
+++ b/models/current_gold_per_floor.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS currentGoldPerFloor (
+        runId TEXT,
+        floor INTEGER,
+        gold INTEGER,
+        PRIMARY KEY (runId, floor)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    floorNum = 0
+    for gold in fjson["gold_per_floor"]:
+        floorNum = floorNum + 1
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO currentGoldPerFloor (
+            runId,
+            floor,
+            gold
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {floorNum},
+            {gold}
+        );
+        """)

--- a/models/current_hp_per_floor.py
+++ b/models/current_hp_per_floor.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS currentHPPerFloor (
+        runId TEXT,
+        floor INTEGER,
+        hp INTEGER,
+        PRIMARY KEY (runId, floor)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    floorNum = 0
+    for hp in fjson["current_hp_per_floor"]:
+        floorNum = floorNum + 1
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO currentHPPerFloor (
+            runId,
+            floor,
+            hp
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {floorNum},
+            {hp}
+        );
+        """)

--- a/models/damage_taken.py
+++ b/models/damage_taken.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS damageTaken (
+        runId TEXT,
+        floor INTEGER,
+        damage INTEGER,
+        turns INTEGER,
+        enemies TEXT,
+        PRIMARY KEY (runId, floor)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    for damage in fjson["damage_taken"]:
+        connection.execute(f"""
+        INSERT OR IGNORE INTO damageTaken (
+            runId,
+            floor,
+            damage,
+            turns,
+            enemies
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {damage["floor"]},
+            {damage["damage"]},
+            {damage["turns"]},
+            "{damage["enemies"]}"
+        );
+        """)

--- a/models/db.py
+++ b/models/db.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import apsw
+import glob
+import json
+
+import boss_relics
+import campfire_choices
+import card_choices
+import current_hp_per_floor
+import current_gold_per_floor
+import damage_taken
+import deck_cards
+import event_choices
+import item_purchases
+import item_purges
+import max_hp_per_floor
+import neow_bonus
+import path_taken
+import potions_obtained
+import relics
+import runs
+
+pkgs = [
+    boss_relics, 
+    campfire_choices,
+    card_choices,
+    current_hp_per_floor,
+    current_gold_per_floor,
+    damage_taken,
+    deck_cards,
+    event_choices,
+    item_purchases,
+    item_purges,
+    max_hp_per_floor,
+    neow_bonus,
+    path_taken,
+    potions_obtained,
+    relics,
+    runs
+]
+
+def create_or_open(dbName):
+    return apsw.Connection(dbName)
+
+def create_tables_if_not_exists(connection):
+    for pkg in pkgs:
+        pkg.create(connection)
+
+def import_files_if_not_imported(connection, pathBase):
+    for filename in glob.iglob(pathBase + '/**/*.run', recursive=True):
+        import_file_if_not_imported(connection, filename)
+
+
+def import_file_if_not_imported(connection, filename):
+    with open(filename) as file:
+            fraw = file.read()
+            fjson = json.loads(fraw)
+            for pkg in pkgs:
+                pkg.insert(connection, fjson)

--- a/models/deck_cards.py
+++ b/models/deck_cards.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import cards
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS deckCards (
+        runId TEXT,
+        cardNum INTEGER,
+        card TEXT,
+        PRIMARY KEY (runId, cardNum)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    cardNum = 0
+    for card in fjson["master_deck"]:
+        cardNum = cardNum + 1
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO deckCards (
+            runId,
+            cardNum,
+            card
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {cardNum},
+            "{cards.to_modern(card)}"
+        );
+        """)

--- a/models/event_choices.py
+++ b/models/event_choices.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS eventChoices (
+        runId TEXT,
+        floor INTEGER,
+        damageHealed INTEGER,
+        damageTaken INTEGER,
+        eventName TEXT,
+        goldGain INTEGER,
+        goldLoss INTEGER,
+        maxHPGain INTEGER,
+        maxHPLoss INTEGER,
+        playerChoice TEXT,
+        PRIMARY KEY (runId, floor)
+    ) WITHOUT ROWID;
+    """)
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS eventRelics (
+        runId TEXT,
+        floor INTEGER,
+        relicNum INTEGER,
+        relic TEXT,
+        PRIMARY KEY (runId, floor, relicNum)
+    ) WITHOUT ROWID;
+    """)
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS eventCards (
+        runId TEXT,
+        floor INTEGER,
+        cardNum INTEGER,
+        card TEXT,
+        PRIMARY KEY (runId, floor, cardNum)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    for event in fjson["event_choices"]:
+        connection.execute(f"""
+        INSERT OR IGNORE INTO eventChoices (
+            runId,
+            floor,
+            damageHealed,
+            damageTaken,
+            eventName,
+            goldGain,
+            goldLoss,
+            maxHPGain,
+            maxHPLoss,
+            playerChoice
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {event["floor"]},
+            {event["damage_healed"]},
+            {event["damage_taken"]},
+            "{event["event_name"]}",
+            {event["gold_gain"]},
+            {event["gold_loss"]},
+            {event["max_hp_gain"]},
+            {event["max_hp_loss"]},
+            "{event["player_choice"]}"
+        );
+        """)
+
+        cardNum = 0
+        for card in [] if "cards_obtained" not in event else event["cards_obtained"]:
+            cardNum = cardNum + 1
+            
+            connection.execute(f"""
+            INSERT OR IGNORE INTO eventCards (
+                runId,
+                floor,
+                cardNum,
+                card
+            ) VALUES (
+                "{fjson["play_id"]}",
+                {event["floor"]},
+                {cardNum},
+                "{card}"
+            );
+            """)
+
+        relicNum = 0
+        for relic in [] if "relics_obtained" not in event else event["relics_obtained"]:
+            relicNum = relicNum + 1
+            
+            connection.execute(f"""
+            INSERT OR IGNORE INTO eventRelics (
+                runId,
+                floor,
+                relicNum,
+                relic
+            ) VALUES (
+                "{fjson["play_id"]}",
+                {event["floor"]},
+                {relicNum},
+                "{relic}"
+            );
+            """)

--- a/models/item_purchases.py
+++ b/models/item_purchases.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS itemPurchases (
+        runId TEXT,
+        floor INTEGER,
+        itemPurchaseNum INTEGER,
+        item TEXT,
+        PRIMARY KEY (runId, floor, itemPurchaseNum)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    itemPurchaseNum = 0
+    for floor in fjson["item_purchase_floors"]:
+        item = fjson["items_purchased"][itemPurchaseNum]
+        itemPurchaseNum = itemPurchaseNum + 1
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO itemPurchases (
+            runId,
+            floor,
+            itemPurchaseNum,
+            item
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {floor},
+            {itemPurchaseNum},
+            "{item}"
+        );
+        """)

--- a/models/item_purges.py
+++ b/models/item_purges.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS itemPurges (
+        runId TEXT,
+        floor INTEGER,
+        itemPurgeNum INTEGER,
+        item TEXT,
+        PRIMARY KEY (runId, floor, itemPurgeNum)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    itemPurgeNum = 0
+    for floor in fjson["items_purged_floors"]:
+        item = fjson["items_purged"][itemPurgeNum]
+        itemPurgeNum = itemPurgeNum + 1
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO itemPurges (
+            runId,
+            floor,
+            itemPurgeNum,
+            item
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {floor},
+            {itemPurgeNum},
+            "{item}"
+        );
+        """)

--- a/models/max_hp_per_floor.py
+++ b/models/max_hp_per_floor.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS maxHPPerFloor (
+        runId TEXT,
+        floor INTEGER,
+        hp INTEGER,
+        PRIMARY KEY (runId, floor)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    floorNum = 0
+    for hp in fjson["max_hp_per_floor"]:
+        floorNum = floorNum + 1
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO maxHPPerFloor (
+            runId,
+            floor,
+            hp
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {floorNum},
+            {hp}
+        );
+        """)

--- a/models/neow_bonus.py
+++ b/models/neow_bonus.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS neowBonus (
+        runId TEXT,
+        bonus TEXT,
+        cost TEXT,
+        PRIMARY KEY (runId)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    connection.execute(f"""
+    INSERT OR IGNORE INTO neowBonus (
+        runId,
+        bonus,
+        cost
+    ) VALUES (
+        "{fjson["play_id"]}",
+        "{fjson["neow_bonus"]}",
+        "{fjson["neow_cost"]}"
+    );
+    """)

--- a/models/path_taken.py
+++ b/models/path_taken.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS pathTaken (
+        runId TEXT,
+        floor INTEGER,
+        node TEXT,
+        PRIMARY KEY (runId, floor)
+    ) WITHOUT ROWID;
+    """)
+
+def switch(nodeRaw):
+    if nodeRaw == "M":
+        return "combat"
+    if nodeRaw == "$":
+        return "shop"
+    if nodeRaw == "R":
+        return "campfire"
+    if nodeRaw == "?":
+        return "event"
+    if nodeRaw == "E":
+        return "elite"
+    if nodeRaw == "BOSS":
+        return "boss"
+
+def insert(connection, fjson):
+    floorNum = 0
+    for nodeRaw in fjson["path_taken"]:
+        floorNum = floorNum + 1
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO pathTaken (
+            runId,
+            floor,
+            node
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {floorNum},
+            "{switch(nodeRaw)}"
+        );
+        """)

--- a/models/potions_obtained.py
+++ b/models/potions_obtained.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS potionsObtained (
+        runId TEXT,
+        potionNum INTEGER,
+        floor INTEGER,
+        key TEXT,
+        PRIMARY KEY (runId, potionNum)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    potionNum = 0
+    for potion in fjson["potions_obtained"]:
+        potionNum = potionNum + 1
+        connection.execute(f"""
+        INSERT OR IGNORE INTO potionsObtained (
+            runId,
+            potionNum,
+            floor,
+            key
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {potionNum},
+            {potion["floor"]},
+            "{potion["key"]}"
+        );
+        """)

--- a/models/relics.py
+++ b/models/relics.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import json
+
+idToName = {
+    "Boot": "The Boot",
+    "Cables": "Gold Plated Cables",
+    "DataDisk": "Data Disk",
+    "Dodecahedron": "Runic Dodecahedron",
+    "Frozen Egg 2": "Frozen Egg",
+    "Lee's Waffle": "Waffle",
+    "Molten Egg 2": "Molten Egg",
+    "NeowsBlessing": "Neows Lament",
+    "Self Forming Clay": "Self-Forming Clay",
+    "Snake Skull": "Snecko Skull",
+    "Toxic Egg 2": "Toxic Egg",
+    "Yang": "Duality",
+}
+
+def to_modern(card):
+    cardParts = card.split("+")
+
+    cardName = cardParts[0]
+    if cardName in idToName:
+        cardName = idToName[cardName]
+    
+    if len(cardParts) == 2:
+        cardName = cardName + "+" + cardParts[1]
+
+    return cardName
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS relics (
+        runId TEXT,
+        relicNum INTEGER,
+        relic TEXT,
+        floorObtained INTEGER,
+        stats TEXT,
+        PRIMARY KEY (runId, relicNum)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    relicStats = {} if "relic_stats" not in fjson else fjson["relic_stats"]
+    relicNum = 0
+    for relic in fjson["relics"]:
+        relicNum = relicNum + 1
+        floorObtained = 0
+        for relicFloor in fjson["relics_obtained"]:
+            if relic == relicFloor["key"]:
+                floorObtained = relicFloor["floor"]
+
+        connection.execute(f"""
+        INSERT OR IGNORE INTO relics (
+            runId,
+            relicNum,
+            relic,
+            floorObtained,
+            stats
+        ) VALUES (
+            "{fjson["play_id"]}",
+            {relicNum},
+            "{to_modern(relic)}",
+            {floorObtained},
+            json('{"{}" if relic not in relicStats else json.dumps(relicStats[relic])}')
+        );
+        """)

--- a/models/runs.py
+++ b/models/runs.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+def create(connection):
+    connection.execute("""
+    CREATE TABLE IF NOT EXISTS runs (
+        runId TEXT,
+        user TEXT,
+        profile INTEGER,
+        ascensionLevel INTEGER,
+        buildVersion TEXT,
+        campfireRested INTEGER,
+        campfireUpgraded INTEGER,
+        characterChosen TEXT,
+        choseSeed INTEGER,
+        circletCount INTEGER,
+        floorReached INTEGER,
+        gold INTEGER,
+        isBeta INTEGER,
+        isDaily INTEGER,
+        isEndless INTEGER,
+        isProd INTEGER,
+        isTrial INTEGER,
+        localTime TEXT,
+        playerExperience INTEGER,
+        playtime INTEGER,
+        purchasedPurges INTEGER,
+        score INTEGER,
+        seedPlayed INTEGER,
+        seedSourceTimestamp TEXT,
+        victory INTEGER,
+        PRIMARY KEY (runId)
+    ) WITHOUT ROWID;
+    """)
+
+def insert(connection, fjson):
+    # TODO: Stop hardcoding the user and profile values.
+    connection.execute(f"""
+    INSERT OR IGNORE INTO runs (
+        runId,
+        user,
+        profile,
+        ascensionLevel,
+        buildVersion,
+        campfireRested,
+        campfireUpgraded,
+        characterChosen,
+        choseSeed,
+        circletCount,
+        floorReached,
+        gold,
+        isBeta,
+        isDaily,
+        isEndless,
+        isProd,
+        isTrial,
+        localTime,
+        playerExperience,
+        playtime,
+        purchasedPurges,
+        score,
+        seedPlayed,
+        seedSourceTimestamp,
+        victory
+    ) VALUES (
+        "{fjson["play_id"]}",
+        "Baalorlord",
+        0,
+        {fjson["ascension_level"]},
+        "{fjson["build_version"]}",
+        {fjson["campfire_rested"]},
+        {fjson["campfire_upgraded"]},
+        "{fjson["character_chosen"]}",
+        {1 if fjson["chose_seed"] else 0},
+        {fjson["circlet_count"]},
+        {fjson["floor_reached"]},
+        {fjson["gold"]},
+        {1 if fjson["is_beta"] else 0},
+        {1 if fjson["is_daily"] else 0},
+        {1 if fjson["is_endless"] else 0},
+        {1 if fjson["is_prod"] else 0},
+        {1 if fjson["is_trial"] else 0},
+        "{fjson["local_time"]}",
+        {fjson["player_experience"]},
+        {fjson["playtime"]},
+        {fjson["purchased_purges"]},
+        {fjson["score"]},
+        {fjson["seed_played"]},
+        "{fjson["seed_source_timestamp"]}",
+        {1 if fjson["victory"] else 0}
+    );
+    """)


### PR DESCRIPTION
# What is this?
These models should make it easier for us to iterate on cool statistics and visualizations on the website. In addition, it should support any future query types, searching, or filtering we wish to do.

These models are at best a first pass, and should not be taken as final. However the method of constructing these models is non-destructive, so it should be safe to iterate on them at any point.

# What is left to do?
Other than iterating on the models themselves, this does not integrate with the existing codebase at all.

If we decide we like this: my recommendation is to move pages over to the SQLite models whenever we happen to be touching a page, rather than moving all at once.

# Any specific things that should be reviewed more closely?
I have never really used python before, so it is likely some of this code needs significantly changed before we think it is good enough! Please let me know what you see, I would be happy to iterate here. 🙇‍♀️ 

A specific example: I am not sure if people like leaning into the more flexible typing python provides, or trying to lock things down more at compile time.

# Example use:
## Program:
```
#!/usr/bin/env python3

import db

with db.create_or_open("baalor200.sqlite") as connection:
    db.create_tables_if_not_exists(connection)

    db.import_files_if_not_imported(connection, "Baalor200")

    print("---------------------------------------------------")
    cursor = connection.cursor()
    cursor.execute("SELECT key, COUNT(*) AS total FROM potionsObtained GROUP BY key ORDER BY total DESC;")
    print(cursor.getdescription())
    for x in cursor:
        print(x)
    print("---------------------------------------------------")
```

## Output:
```
---------------------------------------------------
(('key', 'TEXT'), ('total', None))
('SteroidPotion', 133)
('Weak Potion', 126)
('Block Potion', 123)
('Swift Potion', 121)
('SpeedPotion', 118)
('PowerPotion', 117)
('LiquidMemories', 116)
('Energy Potion', 116)
('AttackPotion', 116)
('Explosive Potion', 115)
('ColorlessPotion', 115)
('DuplicationPotion', 114)
('Fire Potion', 112)
('FearPotion', 108)
('Strength Potion', 101)
('BlessingOfTheForge', 98)
('SkillPotion', 93)
('Ancient Potion', 91)
('GamblersBrew', 90)
('DistilledChaos', 88)
('Dexterity Potion', 86)
('Regen Potion', 80)
('LiquidBronze', 70)
('EssenceOfSteel', 64)
('EntropicBrew', 55)
('FairyPotion', 50)
('CultistPotion', 48)
('Fruit Juice', 46)
('SneckoOil', 39)
('SmokeBomb', 37)
('CunningPotion', 32)
('BloodPotion', 32)
('FocusPotion', 27)
('BottledMiracle', 25)
('PotionOfCapacity', 22)
('Poison Potion', 21)
('ElixirPotion', 19)
('StancePotion', 18)
('GhostInAJar', 13)
('Ambrosia', 11)
('HeartOfIron', 9)
('EssenceOfDarkness', 7)
---------------------------------------------------
```