### PR TITLE
add score to client

### DIFF
--- a/Templates/partials/run_header.jinja2
+++ b/Templates/partials/run_header.jinja2
@@ -20,7 +20,7 @@
             {% if run.done %}
               {{ run.score }} points
             {% else %}
-              On floor {{ run.current_floor }}
+              Current Score: {{ run.score }} points | On floor {{ run.current_floor }}
             {% endif %}
             {% if run.ascension_level != 20 %}
               (A{{ run.ascension_level }})

--- a/Templates/run_single.jinja2
+++ b/Templates/run_single.jinja2
@@ -149,9 +149,21 @@
             {% if run.modifiers %}
             <div>
               <p>Modifiers:</p>
-              {{ run.modifiers_with_desc }}
+              <ul>
+              {% for modifier in run.modifiers_with_desc %}
+                <li>{{ modifier }}</li>
+              {% endfor %}
+              </ul>
             </div>
             {% endif %}
+            <div class="score">
+              <p>Score breakdown:</p>
+              <ul>
+              {% for score in run.score_breakdown %}
+                <li>{{ score }}</li>
+              {% endfor %}
+              </ul>
+            </div>
           </div>
           <div id="neow-body-new" class="message-body hidden">
             <p id="neow-body-content"></p>

--- a/gamedata.py
+++ b/gamedata.py
@@ -677,6 +677,10 @@ class FileParser(ABC):
         return c
 
     @property
+    def modded(self) -> bool:
+        return self.character not in ("Ironclad", "Silent", "Defect", "Watcher")
+
+    @property
     def current_hp_counts(self) -> list[int]:
         return self._data[self.prefix + "current_hp_per_floor"]
 

--- a/gamedata.py
+++ b/gamedata.py
@@ -915,7 +915,7 @@ class FileParser(ABC):
     def modifiers_with_desc(self) -> list[str]:
         if self.modifiers:
             modifiers_with_desc = [get_run_mod(mod) for mod in self.modifiers]
-            return "\n".join(modifiers_with_desc)
+            return modifiers_with_desc
         return []
 
     @property
@@ -925,7 +925,7 @@ class FileParser(ABC):
 
     @property
     @abstractmethod
-    def score_breakdown(self) -> list[str]:
+    def score_breakdown(self) -> str:
         raise NotImplementedError
 
 class RelicData:

--- a/gamedata.py
+++ b/gamedata.py
@@ -925,7 +925,7 @@ class FileParser(ABC):
 
     @property
     @abstractmethod
-    def score_breakdown(self) -> str:
+    def score_breakdown(self) -> list[str]:
         raise NotImplementedError
 
 class RelicData:

--- a/runs.py
+++ b/runs.py
@@ -79,10 +79,6 @@ class RunParser(FileParser):
         return self._data["victory"]
 
     @property
-    def modded(self) -> bool:
-        return self.character not in ("Ironclad", "Silent", "Defect", "Watcher")
-
-    @property
     def verb(self) -> str:
         return "victory" if self.won else "loss"
 

--- a/runs.py
+++ b/runs.py
@@ -104,6 +104,7 @@ class RunParser(FileParser):
 
     @property
     def score_breakdown(self) -> list[str]:
+        print(self._data.get("score_breakdown", []))
         return self._data.get("score_breakdown", [])
 
     @property

--- a/runs.py
+++ b/runs.py
@@ -104,7 +104,6 @@ class RunParser(FileParser):
 
     @property
     def score_breakdown(self) -> list[str]:
-        print(self._data.get("score_breakdown", []))
         return self._data.get("score_breakdown", [])
 
     @property

--- a/save.py
+++ b/save.py
@@ -242,7 +242,7 @@ class Savefile(FileParser):
     @property
     def score_breakdown(self) -> list[str]:
         return [bonus.full_display for bonus in self._get_score_bonuses() 
-                        if bonus.should_show or bonus.score_bonus > 0]
+                        if bonus.should_show or bonus.score_bonus != 0]
 
     def _get_score_bonuses(self) -> list[_s.Score]:
         score_bonuses: list[_s.Score] = []
@@ -263,9 +263,7 @@ class Savefile(FileParser):
         score_bonuses.append(_s.get_shiny_bonus(self))
         score_bonuses.append(_s.get_max_hp_bonus(self))
         score_bonuses.append(_s.get_gold_bonus(self))
-        score_bonuses.append(_s.get_pauper_bonus(self))
         score_bonuses.append(_s.get_curses_bonus(self))
-        score_bonuses.append(_s.get_highlander_bonus(self))
         score_bonuses.append(_s.get_poopy_bonus(self))
         return score_bonuses
 
@@ -312,6 +310,10 @@ class Savefile(FileParser):
     @property
     def act_num(self) -> int:
         return self._data["act_num"]
+
+    @property
+    def deck_card_ids(self) -> list[str]:
+        return [card["id"] for card in self._data["cards"]]
 
 _savefile = Savefile()
 

--- a/score.py
+++ b/score.py
@@ -147,6 +147,7 @@ def get_shiny_bonus(save: Savefile) -> Score:
 
 def get_max_hp_bonus(save: Savefile) -> Score:
     """Get points based on how much max HP gained, ignores Ascension 14 penalty."""
+    bonus = Score()
     max_hp_dict = {
         "Ironclad": 80,
         "Silent": 70,
@@ -154,13 +155,12 @@ def get_max_hp_bonus(save: Savefile) -> Score:
         "Watcher": 72
     }
 
-    max_hp_gain = save.max_health - max_hp_dict[save.character]
-    if max_hp_gain >= 30:
-        bonus = Score("Stuffed", score=50)
-    elif max_hp_gain >= 15:
-        bonus = Score("Well Fed", score=25)
-    else:
-        bonus = Score()
+    if save.character in max_hp_dict:
+        max_hp_gain = save.max_health - max_hp_dict[save.character]
+        if max_hp_gain >= 30:
+            bonus = Score("Stuffed", score=50)
+        elif max_hp_gain >= 15:
+            bonus = Score("Well Fed", score=25)
     return bonus
 
 def get_gold_bonus(save: Savefile) -> Score:

--- a/server.py
+++ b/server.py
@@ -986,6 +986,14 @@ async def modifiers(ctx: ContextType, save: Savefile):
     else:
         await ctx.reply("This is a standard run.")
 
+@with_savefile("score")
+async def score(ctx: ContextType, save: Savefile):
+    """Display the current score of the run"""
+    if save.modded:
+        await ctx.reply(f'Current Score: ~{save.score} points')
+    else:
+        await ctx.reply(f'Current Score: {save.score} points')
+
 @command("last")
 async def get_last(ctx: ContextType, arg1: str = "", arg2: str = ""):
     """Get the last run/win/loss."""

--- a/static/main.css
+++ b/static/main.css
@@ -341,10 +341,13 @@ section.section {
   font-size: 0.75em;
 }
 
-.neow .message-body .skipped li {
-  text-decoration: line-through;
+.neow .message-body li {
   list-style: circle;
   margin-left: 1em;
+}
+
+.neow .message-body .skipped li {
+  text-decoration: line-through;
 }
 
 nav.breadcrumb {


### PR DESCRIPTION
Adds score to the ongoing run header.
Adds the score breakdown to the "Neow Bonus" panel (we should probably change this title at this point, right now it houses Neow Bonus, custom run modifiers, and now score breakdown)
Remove Highlander and Pauper from score bonus because they are only for victories.