### PR TITLE
Change refresh method to use HTMX, every 10s

### DIFF
--- a/Templates/base.jinja2
+++ b/Templates/base.jinja2
@@ -23,6 +23,10 @@
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css">
 
+    {# HTMX lets us load data into the pages without a full reload 👀
+    https://htmx.org/ #}
+    <script src="https://unpkg.com/htmx.org@1.8.4"></script>
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
 
     <meta charset="UTF-8">
@@ -131,7 +135,7 @@
         </ul>
       </aside>
 
-      <div id="content">
+      <div id="content" {% if autorefresh %}hx-get="/current?content_only=1" hx-trigger="every 10s"{% endif %}>
         {% block content %}{% endblock %}
       </div>
 

--- a/Templates/content.jinja2
+++ b/Templates/content.jinja2
@@ -1,0 +1,4 @@
+{# This can be extended into to only render the content block. This is useful
+for the websocket polling things #}
+
+{% block content %}{% endblock %}

--- a/Templates/run_single.jinja2
+++ b/Templates/run_single.jinja2
@@ -1,4 +1,8 @@
-{% extends "base.jinja2" %}
+{% if extend_base %}
+  {% extends "base.jinja2" %}
+{% else %}
+  {% extends "content.jinja2" %}
+{% endif %}
 
 {% block title %}
   {% if run.done or run.in_game %}
@@ -9,12 +13,6 @@
 {% endblock %}
 
 {% block head %}
-  {% if autorefresh %}
-    <!-- Refresh the page every 15 seconds; savefile gets regularly updated.
-         Actual code will properly cache the savefile and serve latest -->
-    <meta http-equiv="refresh"
-      content="{% if redirect and parser.in_game %}0;url=/current{% else %}15{% endif %}">
-  {% endif %}
   <script src="/static/js/run.js"></script>
 {% endblock %}
 

--- a/response_objects/run_single.py
+++ b/response_objects/run_single.py
@@ -8,8 +8,9 @@ if TYPE_CHECKING:
     from runs import RunParser
 
 class RunResponse:
-    def __init__(self, parser: FileParser, run_linked_node: RunLinkedListNode = None, *, autorefresh: bool, redirect: bool):
+    def __init__(self, parser: FileParser, run_linked_node: RunLinkedListNode = None, *, autorefresh: bool, redirect: bool, extend_base: bool):
         self.run = parser
         self.linked_runs = run_linked_node
         self.autorefresh = autorefresh
         self.redirect = redirect
+        self.extend_base = extend_base

--- a/runs.py
+++ b/runs.py
@@ -306,7 +306,7 @@ async def run_single(req: Request):
         raise HTTPNotFound()
     redirect = _truthy(req.query.get("redirect"))
 
-    response = RunResponse(parser, parser.matched, autorefresh=False, redirect=redirect)
+    response = RunResponse(parser, parser.matched, autorefresh=False, redirect=redirect, extend_base=True)
     return convert_class_to_obj(response)
 
 @router.get("/runs/{name}/raw")

--- a/save.py
+++ b/save.py
@@ -364,7 +364,11 @@ def _truthy(x: str | None) -> bool:
 @aiohttp_jinja2.template("run_single.jinja2")
 async def current_run(req: Request):
     redirect = _truthy(req.query.get("redirect"))
-    context = RunResponse(_savefile, autorefresh=True, redirect=redirect)
+    extend_base = True
+    if _truthy(req.query.get("content_only")):
+        extend_base = False
+
+    context = RunResponse(_savefile, autorefresh=True, redirect=redirect, extend_base=extend_base)
     if not _savefile.in_game and not redirect:
         if _savefile._matches and time.time() - _savefile._last <= 60:
             latest = get_latest_run(None, None)


### PR DESCRIPTION
This will make it not reload the full page anymore, only the content.  This is only supported for the `/current` page.  Other pages could easily be changed to use the same mechanic, but I don't think we have any other pages that warrant polling.

There's some logic in the previous refresh thingy that I couldn't figure out what it does.  Sometimes it sets the refresh interval to... zero?  I don't understand it, so I can't replicated it.  Maybe @Vgr255 knows more?

I also lowered the interval to 10s. I think the server should be able to handle that gracefully.