### PR TITLE
Fix: Relative spire path for linux systems

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -33,6 +33,9 @@ def load_file(filename: str) -> DotMap:
 # Load the default configuration file
 config = load_file("./default-config.yml")
 
+# Expand filepaths for *nix systems ('~/' becomes '/home/$USER').  Has no effect otherwise.
+config.spire.steamdir = os.path.expanduser(config.spire.steamdir) 
+
 # Determine which extra file to load values from.
 if len(sys.argv) >= 2:
     # If we have specified a configuration file on the command line, use that.


### PR DESCRIPTION
On linux, the default path for a steam spire install is in a hidden directory in the user's home directory:
`~/.steam/...`, however in python, various os related methods (`os.listdir()`, `os.path()`, etc.) require a full path.

The defaults are contained in the `default-config.yml` file, which gets imported, parsed, and then is passed into the client and used for various purposes.

Updating the initial parsing to expand the path for a given user during config processing allows the full path to be used anywhere it is needed.