### PR TITLE
Add os specific config.spire.steamdir test

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -6,6 +6,7 @@ import sys
 import os
 
 from dotmap import DotMap
+from platform import system
 
 # This is the minimal development config needed.
 DEFAULT_DEV_CONFIG = {
@@ -62,6 +63,17 @@ for key in extra:
     config[key].update(extra[key])
 
 config.filename = extra_file
+
+# If spire.steamdir is not being set via configs, detect the OS and
+# use the OS appropriate default spire steamdir:
+if not config.spire.steamdir:
+    system_os = system().lower()
+    if system_os == "windows":
+        config.spire.steamdir = 'C:\Program Files (x86)\Steam\steamapps\common\SlayTheSpire'
+    elif system_os == "linux":
+        config.spire.steamdir = "~/.steam/steam/steamapps/common/SlayTheSpire"
+    else: # Other Operating systems do not have defaults set
+        raise NotImplementedError(f"No default spire.steamdir set for os: '{system_os}'\nSet spire steamdir manually in config file.")
 
 # Expand filepaths for *nix systems ('~/' becomes '/home/$USER').  Has no effect otherwise.
 config.spire.steamdir = os.path.expanduser(config.spire.steamdir) 

--- a/default-config.yml
+++ b/default-config.yml
@@ -99,9 +99,10 @@ spire:
   # Where the gamedata is located on your computer. This is used by the client to
   # figure out where to look for run files and autosaves.
   # This needs single quotes because Windows uses backslashes.
-  steamdir: 'C:\Program Files (x86)\Steam\steamapps\common\SlayTheSpire'
+  # steamdir: 'C:\Program Files (x86)\Steam\steamapps\common\SlayTheSpire'
   # For Linux:
   # steamdir: "~/.steam/steam/steamapps/common/SlayTheSpire"
+  steamdir: ""
 
   # These are all the enabled mods (used for !info and run history pages)
   enabled_mods: ["Slay the Spire", "Downfall", "The Packmaster"]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from platform import system
+from os.path import expanduser
+
+from configuration import config
+
+class TestConfigFile(TestCase):
+
+    def test_default_spire_steamdir(self):
+        system_os = system().lower()
+        if system_os == "windows":
+            self.assertEqual(config.spire.steamdir, 'C:\Program Files (x86)\Steam\steamapps\common\SlayTheSpire')
+        elif system_os == "linux":
+            self.assertEqual(config.spire.steamdir, expanduser("~/.steam/steam/steamapps/common/SlayTheSpire"))
+        else:
+            self.fail(f"No default spire.steamdir set for os: '{system_os}'\nSet spire steamdir manually in config file.")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -14,4 +14,4 @@ class TestConfigFile(TestCase):
         elif system_os == "linux":
             self.assertEqual(config.spire.steamdir, expanduser("~/.steam/steam/steamapps/common/SlayTheSpire"))
         else:
-            self.fail(f"No default spire.steamdir set for os: '{system_os}'\nSet spire steamdir manually in config file.")
+            self.fail(f"No default spire.steamdir set for os: '{system_os}'")


### PR DESCRIPTION
Added test for default steamdir on windows and linux, with intentional failed test on any other system.