### PR TITLE
Add !seen [boat|boatthingy|boatthingie] meta command

### DIFF
--- a/default-config.yml
+++ b/default-config.yml
@@ -98,10 +98,11 @@ server:
 spire:
   # Where the gamedata is located on your computer. This is used by the client to
   # figure out where to look for run files and autosaves.
-  # This needs single quotes because Windows uses backslashes.
+  # This needs single quotes because Windows uses backslashes. 
   # steamdir: 'C:\Program Files (x86)\Steam\steamapps\common\SlayTheSpire'
   # For Linux:
   # steamdir: "~/.steam/steam/steamapps/common/SlayTheSpire"
+  # Leave blank if StS is installed in the default steam dir on win or linux 
   steamdir: ""
 
   # These are all the enabled mods (used for !info and run history pages)


### PR DESCRIPTION
Restructure `!seen` command to allow composing meta responses via a single `await ctx.reply()` call at the end of the command.