### PR TITLE
Add Youtube page, with interactive table

### DIFF
--- a/Templates/base.jinja2
+++ b/Templates/base.jinja2
@@ -74,31 +74,15 @@
             Merch!
           </a>
 
+          <a href="/youtube" class="navbar-item">
+            <i class="fa-brands fa-youtube"></i>
+            Youtube
+          </a>
+
           <a href="https://twitch.tv/{{ config.twitch.channel }}" class="navbar-item" target="_blank">
             <i class="fa-brands fa-twitch"></i>
             Twitch
           </a>
-
-          <div class="navbar-item has-dropdown is-hoverable">
-            <a href="https://youtube.com/c/Baalorlord" class="navbar-link" target="_blank">
-              <i class="fa-brands fa-youtube"></i>
-              Youtube
-            </a>
-
-            <div class="navbar-dropdown">
-              <a class="navbar-item" href="https://youtube.com/c/Baalorlord" target="_blank">
-                Main channel
-              </a>
-              <hr class="navbar-divider">
-              <a class="navbar-item" href="https://youtube.com/c/BaalorlordArchives" target="_blank">
-                Archive channel
-              </a>
-              <hr class="navbar-divider">
-              <a class="navbar-item" href="https://youtube.com/channel/UCkgqOXw0EQGiwklGEvz26Yg" target="_blank">
-                Non-Spire Variety content
-              </a>
-            </div>
-          </div>
 
           <a href="/discord" class="navbar-item">
             <i class="fa-brands fa-discord"></i>

--- a/Templates/youtube.jinja2
+++ b/Templates/youtube.jinja2
@@ -1,0 +1,147 @@
+{% extends "base.jinja2" %}
+
+{% block title %}
+  Youtube
+{% endblock %}
+
+{% block head %}
+  <script src=" https://cdn.jsdelivr.net/npm/gridjs@6.1.1/dist/gridjs.production.min.js"></script>
+  <link href=" https://cdn.jsdelivr.net/npm/gridjs@6.1.1/dist/theme/mermaid.min.css" rel="stylesheet">
+{% endblock %}
+
+{% block content %}
+  <section class="section">
+    <div class="columns is-centered">
+      <div class="column is-half mt-4">
+        <h1 class="title has-text-centered">
+          Youtube channels
+        </h1>
+      </div>
+    </div>
+    <div class="columns is-variable is-centered has-text-centered mt-4">
+      <a href="https://youtube.com/@Baalorlord" target="_blank" class="container column box is-one-fifth channel">
+        <div class="p-4 is-size-4 has-text-link">
+          Baalorlord
+        </div>
+        <p class="is-size-7 mr-3 ml-3 mb-3">
+          The main channel. <br/>
+          New uploads of Spire content four times per week.
+        </p>
+      </a>
+      <a href="https://youtube.com/@BaalorlordPlays" target="_blank" class="container column box is-one-fifth channel">
+        <div class="p-4 is-size-4 has-text-link">
+          Baalorlord Plays
+        </div>
+        <p class="is-size-7 mr-3 ml-3 mb-3">
+          The variety channel. <br/>
+          Games that aren't Slay the Spire go here.
+        </p>
+      </a>
+      <a href="https://youtube.com/channel/UCOBCFrVoBoHBH7wojml0i0w" target="_blank"  class="container column box is-one-fifth channel">
+        <div class="p-4 is-size-4 has-text-link">
+          Baalorlord Unedited
+        </div>
+        <p class="is-size-7 mr-3 ml-3 mb-3">
+          The archives. <br/>
+          All streams go here, unedited and without refunds.
+        </p>
+      </a>
+      <a href="https://youtube.com/@baalorlordshorts" target="_blank"  class="container column box is-one-fifth channel shorts">
+        <div class="p-4 is-size-4 has-text-link">
+          Baalorlord Shorts
+        </div>
+        <p class="is-size-7 mr-3 ml-3 mb-3">
+          The shorts. <br/>
+          Shorts and clips, vertical style!
+        </p>
+      </a>
+    </div>
+  </section>
+
+  <section class="section columns is-centered">
+    <div class="column is-half mt-4">
+      <h1 class="subtitle has-text-centered">
+        Content per game
+      </h1>
+      <p>
+        The table below contains links to videos and playlists of all the games that Baalor has
+        played on the stream.  You can sort by clicking on the headers, and you can filter in the
+        search field by typing in keywords like "sponsored".
+      </p>
+
+      <p class="chart-disclaimer has-text-centered m-4 is-size-7">
+        The table is not excellent on mobile due to using a library without responsive
+        support.  Please view it on desktop or in desktop mode for a better and more interactive
+        experience.
+      </p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div id="nom-nom-playlists" class="container"></div>
+    <script type="text/javascript">
+     function formatGame(cell) {
+       /* return `<i title="On Steam" class="fa-brands fa-steam"> </i><b>${cell}</b>` */
+       return `<b>${cell}</b>`
+     }
+
+     function formatYoutube(cell) {
+       console.log(cell);
+       var url = cell;
+       var text = 'Youtube link';
+       if (url.startsWith("https://youtu.be/")) {
+         text = 'Video';
+       } else if (url.startsWith("https://www.youtube.com/playlist")) {
+         text = 'Playlist';
+       } else if (url === 'https://www.youtube.com/@Baalorlord') {
+         // This is for the singular case of Slay the Spire
+         text = 'Channel';
+       }
+
+       var icon = '<i title="Youtube" class="fa-brands fa-youtube"></i>&nbsp;';
+       return `${icon}<a href="${url}" target="_blank">${text}</a>`
+     }
+
+
+     new gridjs.Grid({
+       columns: [
+         {
+           id: "Game",
+           name: "Game",
+           formatter: (cell) => gridjs.html(formatGame(cell)),
+         },
+         {
+           id: "Youtube Link",
+           name: "Youtube",
+           formatter: (cell) => gridjs.html(formatYoutube(cell)),
+         },
+         {
+           id: "Origin",
+           name: "Origin",
+           formatter: (cell) => gridjs.html(`${cell}`),
+         },
+       ],
+       search: true,
+       sort: true,
+       data: {{ playlists | safe }},
+       style: {
+         table: {
+           border: '0',
+         },
+         th: {
+           'background-color': '#222229',
+           color: '#dbdbdb',
+           border: 0,
+           'border-radius': '0',
+           'font-size': '1.125rem',
+         },
+         td: {
+           'background-color': '#111117',
+           border: 0,
+           color: '#dbdbdb',
+         }
+       }
+     }).render(document.getElementById("nom-nom-playlists"));
+    </script>
+  </section>
+{% endblock %}

--- a/default-config.yml
+++ b/default-config.yml
@@ -62,6 +62,10 @@ youtube:
   # probably never be lower than 3600.
   cache_timeout: 3600
 
+  # The export URL to the sheet with links to all Youtube playlists.
+  # Can be queried without an API key.
+  playlist_sheet: "https://docs.google.com/spreadsheets/d/1aM27I_YIQZXDEM7MJBU0Mu5-G8vwWMwWKOojRYJySY4/export?format=csv&gid=0"
+
 baalorbot:
   # What prefix the bot listens to
   prefix: "!"

--- a/main.py
+++ b/main.py
@@ -35,6 +35,8 @@ async def main():
         tasks.add(loop.create_task(server.Twitch_startup()))
     if config.discord.enabled:
         tasks.add(loop.create_task(server.Discord_startup()))
+    if config.youtube.get("playlist_sheet"):
+        tasks.add(loop.create_task(server.Youtube_startup()))
 
     tasks.add(loop.create_task(web._run_app(webpage)))
 

--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 import urllib.parse
 import traceback
 import datetime
+import aiohttp
 import asyncio
 import random
 import string
@@ -1908,3 +1909,11 @@ async def Discord_startup():
 
 async def Discord_cleanup():
     await DConn.close()
+
+async def Youtube_startup():
+    async with aiohttp.ClientSession() as session:
+        async with session.get(config.youtube.playlist_sheet) as response:
+            csv = await response.text()
+            with open('data/playlists.csv', 'w') as playlists:
+                playlists.write(csv)
+        logger.info("Youtube playlist sheet downloaded")

--- a/static/main.css
+++ b/static/main.css
@@ -655,3 +655,23 @@ nav.breadcrumb {
 .ongoing img {
   width: 1.5em;
 }
+
+.gridjs-wrapper {
+  -webkit-border-radius: 0 !important;
+  -moz-border-radius: 0 !important;
+  border-radius: 0 !important;
+}
+.gridjs-search input {
+  color: #dbdbdb;
+  background-color: #333339 !important;
+  border: 1px solid #111117 !important;
+}
+.gridjs-tbody .gridjs-tr:nth-child(even) td {
+  background-color: #16161c !important;
+}
+
+.channel.shorts {
+  /* No idea why Bulma is like this, but without this the last element is not*/
+  /* given any of the margin-bottom. */
+  margin-bottom: 1.5rem;
+}

--- a/webpage.py
+++ b/webpage.py
@@ -2,6 +2,7 @@ import datetime
 import math
 import time
 import json
+import csv
 import os
 
 from aiohttp import web, ClientSession
@@ -126,6 +127,26 @@ async def streaking(req: web.Request):
 
     return {
         "streaks": _streak_collections.containers,
+    }
+
+@router.get("/youtube")
+@aiohttp_jinja2.template("youtube.jinja2")
+async def youtube(req: web.Request):
+    playlists = []
+    try:
+        with open('data/playlists.csv') as playfile:
+            # We're using DictReader with a defined set of fields so that if any keys are added to
+            # the sheet the display code here won't break.
+            reader = csv.DictReader(playfile, fieldnames=("Game", "Youtube Link", "Origin"))
+            # Skip the header line (needed when setting fieldnames)
+            next(reader)
+            # Serialize from a special object down to a pure list so we can json dump
+            playlists = [x for x in reader]
+    except FileNotFoundError:
+        logger.warn("Playlist data not found.  Game table will be empty.")
+
+    return {
+        "playlists": json.dumps(playlists),
     }
 
 @router.get("/discord")


### PR DESCRIPTION
![20240301 221135-d](https://github.com/Spireblight/Spireblight/assets/155394/5bda58fd-2a09-4c23-a754-d59e23ead281)

---

### GUI changes
* Add a Youtube page on `/youtube`.  
* Point the menu entry to that page rather than have a dropdown
* Add fourth entry to [@baalorlordshorts](https://youtube.com/@baalorlordshorts)
* Add interactive table with all entries from the [Youtube playlist sheet](https://docs.google.com/spreadsheets/d/1aM27I_YIQZXDEM7MJBU0Mu5-G8vwWMwWKOojRYJySY4/edit#gid=0)

### Functional changes
* Add `server.Youtube_startup()` on server startup.
* This downloads the aforementioned playlist sheet and stores it in `data/playlists.csv`

The startup download is the only way to do it right now.  I couldn't easily figure out how to add a bot command, so I leave that as an exercise to the reviewer :eyes: 