### PR TITLE
Fixes main.py crashing when no profiles are present (slight refactor)

### DIFF
--- a/cache/mastered.py
+++ b/cache/mastered.py
@@ -17,10 +17,11 @@ _mastery_stats = MasteryStats()
 __all__ = ["update_mastery_stats", "get_mastered", "get_current_masteries"]
 
 def update_mastery_stats():
-    try:
-        runs = list(get_profile(0).runs) # BaalorA20 profile
-    except KeyError:
+    profile = get_profile(0)
+    if profile is None:
         runs = []
+    else:
+        runs = list(profile.runs)
 
     if _mastery_stats.last_run_timestamp is None:
         for run in runs:

--- a/cache/streaks.py
+++ b/cache/streaks.py
@@ -14,10 +14,11 @@ _streak_collections = StreakCache(datetime(2023, 10, 24))
 
 def update_streak_collections():
     # First we grab all the runs from the BaalorA20 profile.
-    all_runs = list(get_profile(0).runs)
-    if not all_runs:
+    profile = get_profile(0)
+    if profile is None or not profile.runs:
         logger.info(f"No runs found to group into streak")
         return
+    all_runs = profile.runs
 
     # We build a list of all runs that have happened the cutoff date, sorted with the earliest runs
     # first in the list

--- a/runs.py
+++ b/runs.py
@@ -298,10 +298,9 @@ def _update_cache():
 async def pick_profile(req: Request):
     profiles = []
     for i in range(3):
-        try:
-            profiles.append(get_profile(i))
-        except KeyError:
-            continue
+        profile = get_profile(i)
+        if profile is not None:
+            profiles.append(profile)
 
     if not profiles:
         raise HTTPNotImplemented(reason="No run files were found")

--- a/server.py
+++ b/server.py
@@ -154,10 +154,11 @@ def _create_cmd(output):
             msg = f"Error: command has unsupported formatting key {e.args[0]!r}"
         keywords = {"mt-save": None, "savefile": None, "profile": None, "readline": readline}
         if "$<profile" in msg:
-            try:
-                keywords["profile"] = get_current_profile()
-            except KeyError: # in case we have nothing
+            profile = get_current_profile()
+            if profile is None:
                 msg = f"Error: command requires an existing profile, and none exist."
+            else:
+                keywords["profile"] = profile
         if "$<savefile" in msg:
             keywords["savefile"] = await get_savefile(ctx)
             if keywords["savefile"] is None:
@@ -1763,11 +1764,8 @@ async def _last_run(ctx: ContextType, character: str | None, arg: bool | None):
 async def wall_card(ctx: ContextType):
     """Fetch the card in the wall for the ladder savefile."""
     for i in range(2):
-        try:
-            p = get_profile(i)
-        except KeyError:
-            continue
-        if "ladder" in p.name.lower():
+        p = get_profile(i)
+        if p is not None and "ladder" in p.name.lower():
             break
     else:
         await ctx.reply("Error: could not find Ladder savefile.")

--- a/sts_profile.py
+++ b/sts_profile.py
@@ -38,8 +38,8 @@ def get_current_profile() -> Profile:
 def profile_from_request(req: Request) -> Profile:
     try:
         profile = get_profile(int(req.match_info["profile"]))
-    except KeyError:
-        raise HTTPNotFound()
+        if profile is None:
+            raise HTTPNotFound()
     except ValueError:
         raise HTTPForbidden(reason="profile must be integer")
     return profile

--- a/sts_profile.py
+++ b/sts_profile.py
@@ -30,7 +30,7 @@ _profiles: dict[int, Profile] = {}
 _slots: dict[str, str] = {}
 
 def get_profile(x: int) -> Profile:
-    return _profiles[x]
+    return _profiles.get(x, None)
 
 def get_current_profile() -> Profile:
     return _profiles[int(_slots["DEFAULT_SLOT"])]


### PR DESCRIPTION
Cloning the repo then running `python main.py` crashes because there are no profiles loaded when `update_streak_collections` tries to read them.

It seems a bit more natural to me to return `None` here instead of throwing, but upon making this ~15 lines of changes it seems like this refactor might be more complexity than its worth. I made [another PR](https://github.com/Spireblight/Spireblight/pull/92) with a 2 line change to match the existing style of the code base with catches. I'll close whichever the one the maintainer prefers.