### PR TITLE
decouple ctx from get_savefile

### DIFF
--- a/save.py
+++ b/save.py
@@ -14,7 +14,6 @@ import aiohttp_jinja2
 from response_objects.run_single import RunResponse
 from nameinternal import get, get_card, Relic, Potion
 from sts_profile import get_current_profile
-from typehints import ContextType
 from gamedata import FileParser, BottleRelic, KeysObtained
 from webpage import router
 from logger import logger
@@ -478,10 +477,5 @@ async def receive_save(req: Request):
 
     return Response()
 
-async def get_savefile(ctx: ContextType | None = None) -> Savefile:
-    if _savefile.character is None:
-        if ctx is not None:
-            await ctx.reply("Not in a run.")
-        return
-
+async def get_savefile() -> Savefile:
     return _savefile


### PR DESCRIPTION
Adds `optional_save` field to  `with_savefile` decorator to allow for commands that change output depending on save state.

Updates existing commands that were using hard linked `get_savefile` to use `with_savefile(optional_save=True)`

`_create_cmd` now calls `ctx.reply("Not in a run.")` directly instead of passing `ctx` to `save.py`.