### PR TITLE
Automated predictions & polls

### DIFF
--- a/default-config.yml
+++ b/default-config.yml
@@ -19,6 +19,21 @@ twitch:
   # you're testing things out.
   channel: <channel not set>
 
+  # This indicates whether we should use extended or classic access.
+  # Classic access needs a simple OAuth token, and no additional fluff.
+  # Extended uses the full Authorization Grant Flow mechanism
+  # This mode requires connecting the client to the streamer's Twitch account
+  # To set it up, set this to true, start the server, and then start the client
+  # Once it has been authorized, the bot will start with proper credentials
+  # Using Extended mode allows for more features, defined in scopes
+  # To update scopes, you need to force a re-auth by deleting the token
+  extended:
+    enabled: false
+    # This is the publicly-available Client ID
+    client_id: <value not set>
+    client_secret: <value not set>
+    scopes: []
+
   timers:
     # The default interval for new timers
     default_interval: 900

--- a/gamedata.py
+++ b/gamedata.py
@@ -94,6 +94,10 @@ class NeowBonus:
         return self.parser._data.get("neow_bonus_log")
 
     @property
+    def choice_made(self) -> bool:
+        return bool(self.parser._data["neow_bonus"])
+
+    @property
     def picked(self) -> str:
         cost = self.parser._data["neow_cost"]
         bonus = self.parser._data["neow_bonus"]
@@ -121,6 +125,7 @@ class NeowBonus:
                 yield f"{self.all_costs.get(c, c)} {self.all_bonuses.get(b, b)}"
 
     # All of the Neow Bonus keys should exist together, if more are added, we shouldn't need to add checks for them
+    # dear past self: wtf is the above supposed to mean? 02/09/24
     @property
     def has_data(self) -> bool:
         if "basemod:mod_saves" in self.parser._data:

--- a/logger.py
+++ b/logger.py
@@ -5,7 +5,7 @@ __all__ = ["logger"]
 
 os.makedirs("data", exist_ok=True)
 
-logger = logging.getLogger("Twitch-Discord-Bot")
+logger = logging.getLogger("Spireblight")
 logger.setLevel(logging.DEBUG)
 
 formatter = logging.Formatter("{asctime} :: {levelname:>8} - {message}", "(%Y-%m-%d %H:%M:%S)", "{")

--- a/prediction_terms.json
+++ b/prediction_terms.json
@@ -24,5 +24,35 @@
             "The Spire will Slay US!",
             "Baalor won't make it."
         ]
+    },
+    "extended": {
+        "title": [
+            "How far will we make it?",
+            "Where will Baalor get to?"
+        ],
+        "char_title": [
+            "How far will the {} make it?",
+            "How far can Baalor get the {}?"
+        ],
+        "act1_death": [
+            "Not even past Act 1",
+            "Can't beat Act 1"
+        ],
+        "act2_death": [
+            "We will die in Act 2",
+            "Baalor will fall to Act 2"
+        ],
+        "act3_death": [
+            "Act 3 will do us in",
+            "Can't quite make it past Act 3"
+        ],
+        "act4_death": [
+            "Almost, but not quite past Act 4",
+            "Can't beat Act 4"
+        ],
+        "victory": [
+            "VICTORY!",
+            "The Spire will be Slain!"
+        ]
     }
 }

--- a/prediction_terms.json
+++ b/prediction_terms.json
@@ -1,11 +1,16 @@
 {
     "classic": {
-        "titles": [
+        "title": [
             "Will the run make it?",
             "Will we win?",
             "Is Baalor going to win this?",
             "Will the Spire be Slain today?",
             "Is this the run?"
+        ],
+        "char_title": [
+            "Will the {} make it?",
+            "Does the {} get to win?",
+            "Can we pilot the {} to victory?"
         ],
         "victory": [
             "This IS the run!",

--- a/prediction_terms.json
+++ b/prediction_terms.json
@@ -1,0 +1,23 @@
+{
+    "classic": {
+        "titles": [
+            "Will the run make it?",
+            "Will we win?",
+            "Is Baalor going to win this?",
+            "Will the Spire be Slain today?",
+            "Is this the run?"
+        ],
+        "victory": [
+            "This IS the run!",
+            "We will win, no doubt!",
+            "Baalor will Slay that Spire!",
+            "Oh yeah, we win, no doubt!"
+        ],
+        "defeat": [
+            "Oh, we're toast.",
+            "We don't survive this.",
+            "The Spire will Slay US!",
+            "Baalor won't make it."
+        ]
+    }
+}

--- a/prediction_terms.json
+++ b/prediction_terms.json
@@ -3,8 +3,8 @@
         "title": [
             "Will the run make it?",
             "Will we win?",
-            "Is Baalor going to win this?",
-            "Will the Spire be Slain today?",
+            "Is Baalor gonna win this?",
+            "Will the Spire be Slain?",
             "Is this the run?"
         ],
         "char_title": [
@@ -15,7 +15,7 @@
         "victory": [
             "This IS the run!",
             "We will win, no doubt!",
-            "Baalor will Slay that Spire!",
+            "Baalor'll Slay that Spire!",
             "Oh yeah, we win, no doubt!"
         ],
         "defeat": [
@@ -28,11 +28,11 @@
     "extended": {
         "title": [
             "How far will we make it?",
-            "Where will Baalor get to?"
+            "Where will we get to?"
         ],
         "char_title": [
-            "How far will the {} make it?",
-            "How far can Baalor get the {}?"
+            "Will {} make it?",
+            "Can the {} win?"
         ],
         "act1_death": [
             "Not even past Act 1",

--- a/runs.py
+++ b/runs.py
@@ -121,6 +121,11 @@ class RunParser(FileParser):
         return int(self._data["floor_reached"])
 
     @property
+    def acts_beaten(self) -> int:
+        """Return how many acts were beaten."""
+        return self._data["path_per_floor"].count(None) # None is a boss chest, act 4 transition, AND final screen
+
+    @property
     def final_health(self) -> tuple[int, int]:
         return self._data["current_hp_per_floor"][-1], self._data["max_hp_per_floor"][-1]
 

--- a/save.py
+++ b/save.py
@@ -474,7 +474,7 @@ async def receive_save(req: Request):
 
     in_run = _savefile.in_game
     _savefile.update_data(j, name, req.query["has_run"])
-    if _savefile.in_game ^ in_run:
+    if in_run and not _savefile.in_game:
         run = get_latest_run(None, None)
         await invoke("run_end", run)
     with open(os.path.join("data", "spire-save.json"), "w") as f:

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@ import calendar
 from datetime import datetime
 from typing import Any
 from aiohttp.web import Request, HTTPNotImplemented, HTTPForbidden, HTTPUnauthorized, FileField
-from twitchio import models, http as _http
+from twitchio import models, client, http as _http
 
 import os
 import json
@@ -44,18 +44,18 @@ async def get_req_data(req: Request, *keys: str) -> list[str]:
 
 # TODO: Merge this upstream to TwitchIO eventually
 # DEPCHECK
-async def post_prediction(http: _http.TwitchHTTP, broadcaster_id: int, title: str, outcomes: list[str], prediction_window: int):
+async def post_prediction(app: client.Client, broadcaster_id: int, title: str, outcomes: list[str], prediction_window: int):
     body = {
         "broadcaster_id": broadcaster_id,
         "title": title,
         "prediction_window": prediction_window,
         "outcomes": [{"title": x} for x in outcomes],
     }
-    val = await http.request(
-        _http.Route("POST", "predictions", body=body, token=config.twitch.oauth_token),
+    val = await app._http.request(
+        _http.Route("POST", "predictions", body=body, token=app._http.token),
         paginate=False,
     )
-    return models.Prediction(http, val[0])
+    return models.Prediction(app._http, val[0])
 
 def getfile(x: str, mode: str):
     return open(os.path.join("data", x), mode)

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import calendar
 from datetime import datetime
 from typing import Any
 from aiohttp.web import Request, HTTPNotImplemented, HTTPForbidden, HTTPUnauthorized, FileField
+from twitchio import models, http as _http
 
 import os
 import json
@@ -10,6 +11,7 @@ from configuration import config
 
 __all__ = [
     "get_req_data",
+    "post_prediction",
     "getfile",
     "update_db",
     "convert_class_to_obj",
@@ -39,6 +41,21 @@ async def get_req_data(req: Request, *keys: str) -> list[str]:
         res.append(value)
 
     return res
+
+# TODO: Merge this upstream to TwitchIO eventually
+# DEPCHECK
+async def post_prediction(http: _http.TwitchHTTP, broadcaster_id: int, title: str, outcomes: list[str], prediction_window: int):
+    body = {
+        "broadcaster_id": broadcaster_id,
+        "title": title,
+        "prediction_window": prediction_window,
+        "outcomes": [{"title": x} for x in outcomes],
+    }
+    val = await http.request(
+        _http.Route("POST", "predictions", body=body, token=config.twitch.oauth_token),
+        paginate=False,
+    )
+    return models.Prediction(http, val[0])
 
 def getfile(x: str, mode: str):
     return open(os.path.join("data", x), mode)


### PR DESCRIPTION
Not tested or ready to merge yet.

The final goal is to be able to run polls and predictions automatically, resolve them as the run ends, and act on poll results.

Planned poll features:
- `create` will let us create a new poll based on a few pre-made templates
  - Templates should be able to be created with just JSON, though acting on them will still need code (for now)
  - If the goal is to pick a character to play, it should automatically (with some params the caller can modify) start a prediction
- `info` should just show details about the currently-running poll, or results from the recently-ended one
- `cancel` cancels the poll, discarding votes

Planned prediction features:
- `create` creates a new prediction. Two types are defined at this moment, relating to the number of options (2 or 5).
  - `classic` is just 2 options, "will this win" y/n
  - `extended` is full 5 options, "how far do we get" with dying in acts 1/2/3/4 and win
- `resolve` resolves a prediction. Prevent doing so if it would be automatically resolved later.
- `info` and `cancel` as with poll
- `sync` is a stretch goal; this is to match a started prediction to the bot so it can automatically resolve it