### PR TITLE
Implement ActiveMods Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,13 @@ last_run
 /static/bulma/
 /.vscode/
 .python-version
+
+# emacs files
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*

--- a/activemodinfo.py
+++ b/activemodinfo.py
@@ -1,0 +1,126 @@
+
+
+class ActiveMod():
+
+    def __init__(self, data: dict):
+        """
+        See https://github.com/drummeur/activemods/blob/master/schema.json for the dict schema.
+        A few of the fields are renamed to avoid python keywords
+        """
+
+        if "id" in data:
+            self.modid = data["id"]
+        else:
+            self.modid = ""
+        
+        if "name" in data:
+            self.name = data["name"].strip()
+        else:
+            self.name = ""
+            
+        if "description" in data:
+            self.description = data["description"]
+        else:
+            self.description = ""
+
+        if "authors" in data:
+            self.authors = data["authors"]
+        else:
+            self.authors = []
+
+        if "credits" in data:
+            self.mod_credits = data["credits"]
+        else:
+            self.mod_credits = ""
+
+        if "mod_version" in data:
+            self.mod_version = data["mod_version"]
+        else:
+            self.mod_version = {
+                "version": "unknown",
+                "major": 0,
+                "minor": 0,
+                "patch": 0
+            }
+
+        if "dependencies" in data:
+            self.dependencies = data["dependencies"]
+        else:
+            self.dependencies = []
+
+        if "optional_dependencies" in data:
+            self.optional_dependencies = data["optional_dependencies"]
+        else:
+            self.optional_dependencies = []
+
+        # temporarily making mod_url a property to take care of the InfoMod url
+        # make sure to change this back to "mod_url" when fixing ActiveMods, too
+
+        if "steam_workshop_url" in data:
+            self._mod_url = data["steam_workshop_url"]
+            #self._mod_url = data["mod_url"]
+        else:
+            self._mod_url = ""
+            
+        if "is_steam_workshop_mod" in data:
+            self.is_steam_workshop_mod = data["is_steam_workshop_mod"]
+        else:
+            self.is_steam_workshop_mod = None
+
+    def __str__(self):
+        return self.name
+        
+    @property
+    def mod_url(self) -> str:
+        # infomod is hardcoded until custom URLs are implemented into ActiveMods
+        if self.modid == "obj_infomod2":
+            return "https://casey-c.github.io/slaythespire/infomod.html"
+        else:
+            return self._mod_url
+
+    @property
+    def version(self) -> str:
+        return self.mod_version["version"]
+
+    def _try_get_int_version(self, field: str) -> int:
+        result = 0
+        
+        try:
+            result = int(self.mod_version[version])
+        except (ValueError, KeyError):
+            pass
+        
+        return result
+    
+    @property
+    def major_version(self) -> int:
+        return self._try_get_int_version("major")
+
+    @property
+    def minor_version(self):
+        return self._try_get_int_version("minor")
+
+    @property
+    def patch_version(self):
+        return self._try_get_int_version("patch")
+
+    @property
+    def authors_formatted(self):
+        if len(self.authors) == 0:
+            authors = "An unknown STS modder"
+        elif len(self.authors) == 1:
+            authors = self.authors[0]
+        else:
+            authors = ", ".join(self.authors[:-1])
+            authors += f", and {self.authors[-1]}"
+
+        return authors
+
+    @property
+    def description_formatted(self):
+        if len(self.description) == 0:
+            desc = "This mod is indescribable (because it has no description...)"
+        else:
+            desc = self.description
+
+        return desc

--- a/runs.py
+++ b/runs.py
@@ -24,6 +24,7 @@ from webpage import router
 from logger import logger
 from events import add_listener
 from utils import convert_class_to_obj, get_req_data
+from activemods import ActiveMods, ActiveMod, ACTIVEMODS_KEY
 
 __all__ = ["get_latest_run"]
 
@@ -64,6 +65,7 @@ class RunParser(FileParser):
         self._profile = profile
         self._character_streak = None
         self._rotating_streak = None
+        self._activemods = None
 
     def __repr__(self):
         return f"Run<{self.display_name}>"
@@ -230,6 +232,24 @@ class RunParser(FileParser):
             loop_cached_runs(is_prev=False)
             return StreakInfo(streak_total, position_in_streak, is_ongoing)
         return StreakInfo(0, 0, False)
+
+    @property
+    def has_activemods(self) -> bool:
+        return ACTIVEMODS_KEY in self._data
+    
+    @property
+    def activemods(self) -> ActiveMods:
+        if self._activemods is None:
+            self._activemods = ActiveMods(self._data)
+
+        return self._activemods
+
+    def find_mod(self, mod_name: str) -> ActiveMod | None:
+        return self.activemods.find_mod(mod_name)
+    
+    @property
+    def mods(self) -> list[ActiveMod]:
+        return self.activemods.all_mods
 
 class StreakInfo(NamedTuple):
     streak: int

--- a/save.py
+++ b/save.py
@@ -20,7 +20,7 @@ from logger import logger
 from events import invoke
 from utils import convert_class_to_obj, get_req_data
 from runs import get_latest_run, StreakInfo
-from activemodinfo import ActiveMod
+from activemods import ActiveMods, ActiveMod, ACTIVEMODS_KEY
 
 import score as _s
 
@@ -57,6 +57,7 @@ class Savefile(FileParser):
         self._last = time.time()
         self._matches = False
         self._activemods = None
+        
 
     def update_data(self, data: dict[str, Any] | None, character: str, has_run: str):
         if character.startswith(("1_", "2_")):
@@ -427,50 +428,23 @@ class Savefile(FileParser):
     def deck_card_ids(self) -> list[str]:
         return [card["id"] for card in self._data["cards"]]
 
-    def _get_mods(self) -> list[ActiveMod]:
-        """
-        Get a list of dicts containing the ActiveMods data.
-        Use this helper method to prevent issues with the field not being present in some save files.
-        Lazily caches the ActiveMod instances
-        See this page for the dict schema: https://github.com/drummeur/activemods/blob/master/schema.json
-        """
-
+    @property
+    def has_activemods(self) -> bool:
+        return ACTIVEMODS_KEY in self._data
+    
+    @property
+    def activemods(self) -> ActiveMods:
         if self._activemods is None:
-            self._activemods = []
-
-            if "activemods:active_mods" in self._data:
-                logger.debug(self._data["activemods:active_mods"])
-                for x in self._data["activemods:active_mods"]:
-                    self._activemods.append(ActiveMod(x))
+            self._activemods = ActiveMods(self._data)
 
         return self._activemods
 
-    def find_mod(self, mod_name: str, ignore_caps=True, ignore_spaces=True) -> dict | None:
-        """
-        Find a mod, based on its name.
-        """
-
-        names = [x.name for x in self.mods]
-
-        if ignore_caps:
-            mod_name = mod_name.lower()
-            names = [x.lower() for x in names]
-
-        if ignore_spaces:
-            mod_name = mod_name.replace(" ", "")
-            names = [x.replace(" ", "") for x in names]
-
-        result = None
-
-        if mod_name in names:
-            idx = names.index(mod_name)
-            result = self.mods[idx]
-
-        return result
+    def find_mod(self, mod_name: str) -> ActiveMod | None:
+        return self.activemods.find_mod(mod_name)
     
     @property
     def mods(self) -> list[ActiveMod]:
-        return self._get_mods()
+        return self.activemods.all_mods
 
 _savefile = Savefile()
 

--- a/server.py
+++ b/server.py
@@ -2694,27 +2694,37 @@ async def calipers(ctx: ContextType, save: Optional[Savefile]):
             msg = "We have Calipers at home! baalorSmug\nAt home: Blur"
     await ctx.reply(msg)
 
-@with_savefile("mods")
+@with_savefile("mods", optional_save=True)
 async def active_mods(ctx: ContextType, save: Savefile):
+    # use the old message if we don't have info from activemods
+    if save and save.has_activemods:
+        names = [x.name for x in save.mods]
+        mods = ", ".join(names[:-1])
+        mods += f", and {names[-1]}"
+        msg = f"For this run, we're using the mods {mods}\nFor more info, try !mod [mod name]"
+    else:
+        msg = "Baalor uses a variety of mods for the stream. You can see a list of all mods here: https://baalorlord.tv/mods"
 
-    names = [x.name for x in save.mods]
-    mods = ", ".join(names[:-1])
-    mods += f", and {names[-1]}"
-    msg = f"For this run, we're using the mods {mods}"
     await ctx.reply(msg)
 
 @with_savefile("mod")
 async def active_mod_info(ctx: ContextType, save: Savefile, *modname):
-    modname = " ".join(modname)
+    # don't do anything if we don't have info from activemods
+    if save.has_activemods:
+        modname = " ".join(modname).strip()
 
-    mod = save.find_mod(modname)
+        if len(modname) == 0:
+            choice = random.choice([x.name for x in save.mods])
+            msg = f"This can tell you information about a specific mod.  Use it like this: !mod {choice}"
+        else:
+            mod = save.find_mod(modname)
 
-    if mod is None:
-        msg = f"Couldn't find any mod called {modname}"
-    else:                                
-        msg = f"{mod.name} was created by {mod.authors_formatted}.\nDescription: {mod.description_formatted}\nTry it out here: {mod.mod_url}"
+            if mod is None:
+                msg = f"Couldn't find any mod called {modname}"
+            else:                                
+                msg = f"{mod.name} was created by {mod.authors_formatted}.\nDescription: {mod.description_formatted}\nTry it out here: {mod.mod_url}"
 
-    await ctx.reply(msg)
+        await ctx.reply(msg)
 
 
 @router.get("/commands")

--- a/server.py
+++ b/server.py
@@ -2694,6 +2694,28 @@ async def calipers(ctx: ContextType, save: Optional[Savefile]):
             msg = "We have Calipers at home! baalorSmug\nAt home: Blur"
     await ctx.reply(msg)
 
+@with_savefile("mods")
+async def active_mods(ctx: ContextType, save: Savefile):
+
+    names = [x.name for x in save.mods]
+    mods = ", ".join(names[:-1])
+    mods += f", and {names[-1]}"
+    msg = f"For this run, we're using the mods {mods}"
+    await ctx.reply(msg)
+
+@with_savefile("mod")
+async def active_mod_info(ctx: ContextType, save: Savefile, *modname):
+    modname = " ".join(modname)
+
+    mod = save.find_mod(modname)
+
+    if mod is None:
+        msg = f"Couldn't find any mod called {modname}"
+    else:                                
+        msg = f"{mod.name} was created by {mod.authors_formatted}.\nDescription: {mod.description_formatted}\nTry it out here: {mod.mod_url}"
+
+    await ctx.reply(msg)
+
 
 @router.get("/commands")
 @template("commands.jinja2")

--- a/trie.py
+++ b/trie.py
@@ -1,0 +1,5 @@
+
+
+class trie():
+    def __init__(self, words):
+        pass

--- a/trie.py
+++ b/trie.py
@@ -1,5 +1,152 @@
+from enum import Enum
+
+class Trie():
+    # we want:
+    ## search a string and return (ideally) a single string that most closely matches
+    ## to be able to create everything in one fell swoop, not have to insert everything all at once
+    # however, i don't have time to do the space-optimized trie right now, and honestly it doesn't really matter
+    # because it's only ever going to hold like 20 strings max
+
+    # words:
+    ## deck, did, dog, dogs, doggie, doe, do
+    # uncompressed
+    #    $
+    #    |
+    #    d
+    #   /|\
+    #  e i o
+    #  | | |\
+    #  c d g e
+    #  |   |\
+    #  k   s g
+    #        |
+    #        g
+    #        |
+    #        i
+    #        |
+    #        e
+
+    # compressed
+    #  (root)
+    #    |
+    #    d
+    #   /|\
+    #  e i o
+    #  c d |\
+    #  k   g e
+    #      |\
+    #      s g
+    #        g
+    #        i
+    #        e
+
+    # to insert a word = w_0 .. w_i
+    # traverse the tree.
+    # at each node n = n_0 .. n_j:
+    #   if we fully match a child:
+    #     follow that edge and repeat
+    #   otherwise:
+    #     find the last index we match, k
+    #     redefine n := n_0 .. n_k (note by definition this is also w_0 .. w_k)
+    #     add children n_(k+1) .. n_j and w_(k+1) .. w_i
+    # 
+  
+    class node():
+        def __init__(self, depth):
+            self.depth = depth
+            self.children = {}
+            self.is_end = False            
+
+        def __iter__(self):
+            yield from self.__iter_helper([])
+
+        def __iter_helper(self, prefix):
+            if self.is_end:
+                yield "".join(prefix)
+            for k,v in self.children.items():
+                yield from v.__iter_helper(prefix + [k])
+            
+        def is_match(self, word):
+            node = self.__match(word)
+            return node.is_end and node.depth == len(word)
+
+        def __match(self, word):
+            if self.depth >= len(word) or word[self.depth] not in self.children:
+                return self
+            else:
+                return self.children[word[self.depth]].__match(word)
+
+        def search(self, word):
+            node = self.__match(word)
+            yield from node.__iter_helper([x for x in word[:node.depth]])
+
+        def __search(self, word, acc):
+            if self.is_end:
+                pass
+                     
+        def add_child(self, word):
+            self.__add_child(word)
+            
+        def __add_child(self, word):
+            if self.depth >= len(word):
+                self.is_end = True
+            elif word[self.depth] in self.children:
+                self.children[word[self.depth]].__add_child(word)
+            else:
+                newnode = Trie.node(self.depth+1)
+                self.children[word[self.depth]] = newnode
+                newnode.__add_child(word)
+    
+    def __init__(self):
+        self.root = Trie.node(0)
+
+    def __iter__(self):
+        yield from self.root
+
+    def __contains__(self, word):
+        return self.root.is_match(word)
+        
+    def insert(self, word):
+        self.root.add_child(word)
+
+    def search(self, word):
+        return list(self.root.search(word))
 
 
-class trie():
-    def __init__(self, words):
-        pass
+# this stuff happens if you run this as a script instead of importing it as a package
+if __name__ == "__main__":
+    t = Trie()
+
+    words = [
+        "admiration",
+        "acute",
+        "assignment",
+        "answer",
+        "bottle",
+        "back",
+        "bulletin",
+        "bird",
+        "competence",
+        "cord",
+        "cousin",
+        "circle",
+        "claim",
+        "deck",
+        "did",
+        "dog",
+        "dogs",
+        "doggie",
+        "doe",
+        "do",
+    ]
+
+    for x in words:
+        t.insert(x)
+
+    #for x in t:
+    #    print(x)
+
+    print(len(t.search("doreimi")))
+
+    for x in t.search(""):
+        print(x)      

--- a/utils.py
+++ b/utils.py
@@ -120,3 +120,31 @@ def _parse_dates_with_optional_month_day(val: str, isEndDate: bool = False) -> d
         return datetime(year, month, day, hour=23, minute=59, second=59)
     else:
         return datetime(year, month, day)
+
+
+def edit_distance(left, right):
+    m = len(left) + 1
+    n = len(right) + 1
+
+    d = [[0 for _ in range(0, n)] for _ in range(0, m)]
+
+    for i in range(1, m):
+        d[i][0] = i
+
+    for i in range(1, n):
+        d[0][i] = i
+
+    for i in range(1, m):
+        for j in range(1, n):
+            if left[i-1] == right[j-1]:
+                subCost = 0
+            else:
+                subCost = 1
+
+            d[i][j] = min(
+                d[i-1][j] + 1, # deletion
+                d[i][j-1] + 1, # insertion
+                d[i-1][j-1] + subCost # substitution
+            )
+
+    return d[len(left)][len(right)]


### PR DESCRIPTION
Adds support for [ActiveMods](https://github.com/drummeur/activemods) ([Steam link](https://steamcommunity.com/sharedfiles/filedetails/?id=3406446784)).
- When that mod is installed, extra information is added to both run and save files
- 2 new commands:
  - `!mods` lists the names of all the mods currently in use in a run
  - `!mod [mod_name]` lists information about a specific mod
    - Uses a trie and Levenshtein distance for fuzzy string matching, because it amused me
- Model classes for ActiveMods and ActiveMod
- Emacs-specific .git_ignore entries that nobody else will ever utilize
- Way too many comments in tries.py because I still want to optimize that class some more
- Probably only a handful of spelling mistakes