### PR TITLE
Support bot-level scopes

### DIFF
--- a/client.py
+++ b/client.py
@@ -115,29 +115,58 @@ async def main():
     if cfg.modded:
         spire2_saves /= "modded"
 
+    needs_restart = False
+
     async with ClientSession(cfg.server_url) as session:
         # Check if the app is registered, prompt it if not
         try:
-            async with session.post("/twitch/check-token", params={"key": cfg.secret}) as resp:
-                if resp.ok:
-                    text = await resp.text()
-                    match text:
-                        case "DISABLED":
-                            print("\nTwitch connectivity is disabled.")
-                        case "NO_CREDENTIALS":
-                            print("\nExtended OAuth is not properly set-up. Contact the server owner.")
-                        case "WORKING":
-                            print("\nExtended OAuth validated.")
-                        case a:
-                            if a.startswith("NEEDS_CONNECTION"):
-                                nc, cl, url = a.partition(":")
-                                import webbrowser
-                                webbrowser.open_new_tab(url)
-                            else:
-                                print(f"\nERROR: Unrecognized return value:\n\n{a}")
+            for ttype in ("broadcaster", "bot"):
+                if ttype == "broadcaster":
+                    print("Verifying channel access permissions . . .")
+                else:
+                    print("Verifying Twitch bot permissions . . .")
+                async with session.post(f"/twitch/check-token/{ttype}", params={"key": cfg.secret}) as resp:
+                    if resp.ok:
+                        text = await resp.text()
+                        match text:
+                            case "DISABLED":
+                                print("\nTwitch connectivity is disabled.")
+                                break
+                            case "NO_CREDENTIALS":
+                                print("\nExtended OAuth is not properly set-up. Contact the server owner.")
+                                break
+                            case "WORKING":
+                                print("\nExtended OAuth validated.")
+                            case "UNKNOWN_TYPE":
+                                print(f"Type {ttype!r} unrecognized (this is a bug).")
+                            case a:
+                                if a.startswith("NEEDS_CONNECTION"):
+                                    needs_restart = True
+                                    nc, cl, url = a.partition(":")
+                                    ob = True # do we open a browser window?
+                                    if ttype == "bot":
+                                        val = input(
+                                            "--==-- Twitch bot access required --==--\n"
+                                            "Please login to your Twitch bot account.\n\n"
+                                            "Then press Enter, and make sure to authorize to the bot account!\n"
+                                            "If this doesn't work for whatever reason, type in 'Link' then Enter. "
+                                            )
+                                        if val: # anything at all, really
+                                            ob = False
+                                            print(f"Please copy-paste the following in your browser:\n\n{url}")
+                                    if ob:
+                                        import webbrowser
+                                        webbrowser.open_new_tab(url)
+                                    input("\nPress Enter if the handshake is successful.")
+                                else:
+                                    print(f"\nERROR: Unrecognized return value:\n\n{a}")
 
         except (ClientError, ServerDisconnectedError):
             print("\nServer is offline, cannot confirm OAuth mode.\nYou may safely ignore this if you previously authorized the app.")
+
+        if needs_restart:
+            input("Please wait for the server to reboot, then restart this.")
+            exit()
 
         while True:
             try:

--- a/default-config.yml
+++ b/default-config.yml
@@ -37,7 +37,11 @@ twitch:
   client_id: ""
   client_secret: ""
 
-  scopes: []
+  # These are channel scopes, i.e. what we are allowed to do on the channel
+  scopes: ["channel:bot"]
+
+  # And these are the scopes the bot user itself (us) will have
+  bot_scopes: ["user:bot", "user:read:chat", "user:write:chat"]
 
   timers:
     # The default interval for new timers

--- a/default-config.yml
+++ b/default-config.yml
@@ -38,6 +38,8 @@ twitch:
   client_secret: ""
 
   # These are channel scopes, i.e. what we are allowed to do on the channel
+  # If you change any of them, make sure to delete the data/tokens.json file
+  # This will force a re-auth (via the client)
   scopes: ["channel:bot"]
 
   # And these are the scopes the bot user itself (us) will have

--- a/src/_cfgmap.py
+++ b/src/_cfgmap.py
@@ -83,7 +83,8 @@ class Config(_ConfigMapping):
             raise RuntimeError(f"Unrecognized config values: {', '.join(kwargs.keys())}")
 
 class Twitch(_ConfigMapping):
-    def __init__(self, channel: str, enabled: bool, editors: list[str], bot_id: int, owner_id: int, client_id: str, client_secret: str, scopes: list[str], timers: dict):
+    def __init__(self, channel: str, enabled: bool, editors: list[str], bot_id: int, owner_id: int,
+                 client_id: str, client_secret: str, scopes: list[str], bot_scopes: list[str], timers: dict):
         """Handle the Twitch aspect of the configuration.
 
         :param channel: The channel name to connect to.
@@ -100,8 +101,10 @@ class Twitch(_ConfigMapping):
         :type client_id: str
         :param client_secret: The Twitch app Client Secret.
         :type client_secret: str
-        :param scopes: a list of the scopes requested, defaults to None.
+        :param scopes: A list of the channel scopes requested, defaults to None.
         :type scopes: list[str] | None, optional
+        :param bot_scopes: The scopes needed for the bot to function.
+        :type bot_scopes: list[str] | None, optional
         :param timers: A mapping that will be used for timer interval.
         :type timers: dict
         """
@@ -118,6 +121,7 @@ class Twitch(_ConfigMapping):
         self.client_secret = client_secret
 
         self.scopes = scopes or []
+        self.bot_scopes = bot_scopes or []
 
         self.timers = _TimerIntervals(**timers)
 

--- a/src/server.py
+++ b/src/server.py
@@ -3214,7 +3214,7 @@ async def automatic_client_report(req: Request):
 _oauth_state = None
 
 
-@router.post("/twitch/check-token")
+@router.post("/twitch/check-token/{type}")
 async def check_token_validity(req: Request):
     await get_req_data(req)  # check if the key is OK
     if not config.twitch.enabled:
@@ -3222,7 +3222,17 @@ async def check_token_validity(req: Request):
     if not (config.twitch.client_id and config.twitch.client_secret):
         return Response(text="NO_CREDENTIALS")
 
-    if str(config.twitch.owner_id) in TConn.tokens:
+    match req.match_info["type"]:
+        case "broadcaster":
+            id_ = config.twitch.owner_id
+            scopes = config.twitch.scopes
+        case "bot":
+            id_ = config.twitch.bot_id
+            scopes = config.twitch.bot_scopes
+        case t:
+            return Response(text="UNKNOWN_TYPE")
+
+    if str(id_) in TConn.tokens:
         return Response(text="WORKING")
 
     # Need to authenticate for the first time (presumably)
@@ -3236,7 +3246,7 @@ async def check_token_validity(req: Request):
         "client_id": config.twitch.client_id,
         "redirect_uri": f"{config.server.url}/twitch/receive-token",
         "response_type": "code",
-        "scope": " ".join(config.twitch.scopes),
+        "scope": " ".join(scopes),
         "state": _oauth_state,
     }
 


### PR DESCRIPTION
This adds support for bot-level scopes, e.g. announcement permissions. This closes #110 (and also closes #128).